### PR TITLE
Bump module version to 1.0.3 and add OMG.PSUtilities.Core as a required module

### DIFF
--- a/OMG.PSUtilities.AzureCore/OMG.PSUtilities.AzureCore.psd1
+++ b/OMG.PSUtilities.AzureCore/OMG.PSUtilities.AzureCore.psd1
@@ -51,7 +51,7 @@ PowerShellVersion = '5.1'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-# RequiredModules = @()
+RequiredModules = @('OMG.PSUtilities.Core')
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()

--- a/OMG.PSUtilities.AzureCore/OMG.PSUtilities.AzureCore.psd1
+++ b/OMG.PSUtilities.AzureCore/OMG.PSUtilities.AzureCore.psd1
@@ -12,7 +12,7 @@
 RootModule = 'OMG.PSUtilities.AzureCore.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.2'
+ModuleVersion = '1.0.3'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/OMG.PSUtilities.AzureCore/plasterManifest.xml
+++ b/OMG.PSUtilities.AzureCore/plasterManifest.xml
@@ -2,7 +2,7 @@
   <metadata>
     <name>OMG.PSUtilities.AzureCore</name>
     <id>3b9e052d-0931-4f80-9d61-761b2eeb0b65</id>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <title>OMG.PSUtilities.AzureCore</title>
     <description>Core Azure-related scripting, including identity and subscription management.</description>
     <author>OMG IT Solutions</author>


### PR DESCRIPTION
This pull request updates the OMG.PSUtilities.AzureCore module to version 1.0.3 and adds 'OMG.PSUtilities.Core' to the RequiredModules section in the module manifest.

**Changes:**

*   **OMG.PSUtilities.AzureCore/OMG.PSUtilities.AzureCore.psd1:**
    *   Updated ModuleVersion from 1.0.2 to 1.0.3.
    *   Added 'OMG.PSUtilities.Core' to RequiredModules.
*   **OMG.PSUtilities.AzureCore/plasterManifest.xml:**
    *   Updated ModuleVersion from 1.0.2 to 1.0.3.

**Rationale:**

*   Incrementing the module version ensures proper versioning and dependency management.
*   Adding 'OMG.PSUtilities.Core' to RequiredModules explicitly declares the dependency, ensuring that the module is loaded before OMG.PSUtilities.AzureCore. This prevents potential issues caused by missing dependencies.

