### PR TITLE
Fix: Corrected module name in RequiredModules of OMG.PSUtilities.AzureDevOps.psd1

### DIFF
--- a/OMG.PSUtilities.AzureDevOps/OMG.PSUtilities.AzureDevOps.psd1
+++ b/OMG.PSUtilities.AzureDevOps/OMG.PSUtilities.AzureDevOps.psd1
@@ -51,7 +51,7 @@ PowerShellVersion = '7.1'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @('OMG.PSUtilities.Core', 'OMG.PSUtilities.Ai')
+RequiredModules = @('OMG.PSUtilities.Core', 'OMG.PSUtilities.AI')
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()


### PR DESCRIPTION
## Description of the Change

This pull request corrects a typo in the `OMG.PSUtilities.AzureDevOps.psd1` module manifest file. The `RequiredModules` section incorrectly referenced 'OMG.PSUtilities.Ai'. This change corrects the module name to 'OMG.PSUtilities.AI'.

## Motivation and Context
This change is required to ensure that the `OMG.PSUtilities.AzureDevOps` module correctly identifies and loads its dependency on the `OMG.PSUtilities.AI` module. An incorrect module name will prevent the Azure DevOps module from functioning correctly if it relies on any functions/cmdlets from the AI module. This resolves a potential import failure when the module is loaded and prevents the dependency from being resolved correctly.

## How Has This Been Tested?
This change has been tested by:

*   Manually inspecting the `OMG.PSUtilities.AzureDevOps.psd1` file to verify the correction.
*   Importing the `OMG.PSUtilities.AzureDevOps` module after the change to confirm that it loads without errors and correctly identifies the `OMG.PSUtilities.AI` module as a dependency.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.