### PR TITLE
Update LicenseUri and ProjectUri in OMG.PSUtilities.AzureDevOps Module

### DIFF
--- a/OMG.PSUtilities.AzureDevOps/OMG.PSUtilities.AzureDevOps.psd1
+++ b/OMG.PSUtilities.AzureDevOps/OMG.PSUtilities.AzureDevOps.psd1
@@ -101,10 +101,10 @@ PrivateData = @{
         # Tags = @()
 
         # A URL to the license for this module.
-        # LicenseUri = ''
+        # LicenseUri = 'https://opensource.org/licenses/MIT'
 
         # A URL to the main website for this project.
-        # ProjectUri = ''
+        # ProjectUri = 'https://github.com/lakshmanachari-panuganti/OMG.PSUtilities'
 
         # A URL to an icon representing this module.
         # IconUri = ''


### PR DESCRIPTION
## Description of the Change
This Pull Request updates the `LicenseUri` and `ProjectUri` properties within the `PrivateData` section of the `OMG.PSUtilities.AzureDevOps.psd1` module manifest file. This ensures the module's metadata accurately reflects the current licensing and project information.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it closes an open work item, please link to the work item here. -->
Ensuring accurate metadata, including license and project URIs, is crucial for proper module identification, discoverability, and usage. This update resolves potential discrepancies and maintains the module's integrity.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
*   Verified the updated `LicenseUri` and `ProjectUri` in the module manifest file.
*   Confirmed the module can be imported and its metadata is accessible via `Get-Module`.
*   Manually reviewed the updated URIs to ensure they are valid and point to the correct resources.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Patch change (Improvement to existing feature)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.