### PR TITLE
Update OMG.PSUtilities.AI module manifest to require Microsoft.PowerShell.ThreadJob

### DIFF
--- a/OMG.PSUtilities.AI/OMG.PSUtilities.AI.psd1
+++ b/OMG.PSUtilities.AI/OMG.PSUtilities.AI.psd1
@@ -51,7 +51,7 @@ PowerShellVersion = '5.1'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @('OMG.PSUtilities.Core')
+RequiredModules = @('OMG.PSUtilities.Core','Microsoft.PowerShell.ThreadJob')
 
 
 # Assemblies that must be loaded prior to importing this module


### PR DESCRIPTION
This pull request introduces the following improvements:

**OMG.PSUtilities.AI/OMG.PSUtilities.AI.psd1 | Updated**  
*Added 'Microsoft.PowerShell.ThreadJob' to the RequiredModules alongside 'OMG.PSUtilities.Core'*

### **Additional Information**

- **Module Dependency Update:** This change ensures that the Microsoft.PowerShell.ThreadJob module is automatically imported before OMG.PSUtilities.AI, as it is now a required dependency. This follows PowerShell best practices for managing module dependencies in the manifest to prevent loading failures due to missing prerequisites.