### PR TITLE
ci: gate PSGallery publishing behind an approved environment

### DIFF
--- a/.github/workflows/Publish-Modules.yml
+++ b/.github/workflows/Publish-Modules.yml
@@ -28,8 +28,27 @@ jobs:
   publish:
     name: Validate, Package, and Publish
     runs-on: windows-latest
+    # Publishing to PowerShell Gallery cannot be undone - a version, once public, stays
+    # public. The environment adds a required reviewer and restricts deployments to main,
+    # so no merge alone reaches the gallery and PSGALLERY_API_KEY is unreachable from any
+    # run that has not been approved.
+    environment: psgallery
 
     steps:
+      # workflow_dispatch can be started from ANY ref, and the run uses the workflow file
+      # from that ref. Without this, a branch carrying a modified copy of this file would
+      # execute with the gallery key attached.
+      - name: Refuse to publish from anything but main
+        shell: pwsh
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          if ($env:REF -ne 'refs/heads/main') {
+              Write-Host "::error::Publishing may only run from refs/heads/main. This run is on $env:REF."
+              exit 1
+          }
+          Write-Host 'Running from main.'
+
       - name: Checkout Repository
         uses: actions/checkout@v7
         with:


### PR DESCRIPTION
Publishing to PowerShell Gallery is irreversible - a version, once public, stays public. Two gaps closed before this repository is onboarded onto the agent lifecycle.

The publish job now runs in the `psgallery` environment, which requires a reviewer and restricts deployments to main. A merge alone no longer reaches the gallery.

workflow_dispatch could be started from ANY ref, and the run uses the workflow file from that ref - so a branch carrying a modified copy of this file would have executed with PSGALLERY_API_KEY attached. The job now refuses any ref but main. This is the same hole that was closed in the governance reconciler.

Recommended follow-up you would need to do by hand: move PSGALLERY_API_KEY from a repository secret to an environment secret on `psgallery`. The environment already gates when the job may run; moving the secret also makes it unreadable to any other job.