### PR TITLE
ci: enable the review and developer agents

### DIFF
--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -1,8 +1,9 @@
 name: PR Lifecycle
 
-# Thin caller. The implementation lives in the administration repository.
-# language: none - Validate.yml already runs PSScriptAnalyzer and the Pester suite as
-# the required "Validate, Test, and Build" check; duplicating it here would prove nothing.
+# Thin caller. The implementation lives in the administration repository so a fix
+# reaches every repository at once.
+#
+# language: none - Validate.yml already runs PSScriptAnalyzer and Pester as the required check.
 
 on:
   pull_request:
@@ -16,5 +17,5 @@ jobs:
     with:
       language: none
       test-command: ''
-      enable-agents: false
+      enable-agents: true
     secrets: inherit


### PR DESCRIPTION
The plumbing is proven on this repository: flow, guard and the ai-review gate have all run green.

What this changes: the reviewer agent will review pull requests from ai-driven1 and publish its verdict, and the developer agent will respond to changes_requested by pushing fixes. Both are bounded - the reviewer holds contents:read and cannot push at all, and the developer cannot touch .github/, infra/, package.json, next.config.* or the other paths CI executes with credentials.

Nothing reaches main from this: main requires code-owner approval and GitHub Apps cannot be code owners.