### PR TITLE
fix: add the missing Complete-PSUGithubPullRequest command

### DIFF
--- a/OMG.PSUtilities.Core/CHANGELOG.md
+++ b/OMG.PSUtilities.Core/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.1.0] - 6th August 2026
+### Added
+- New `Complete-PSUGithubPullRequest` (Public): Merges a GitHub pull request using the REST API, supports the merge, squash, and rebase strategies, and optionally deletes the source branch. `Complete-PSUPullRequest` already routed GitHub repositories to this command, but it had never been implemented.
+
+### Fixed
+- `Complete-PSUPullRequest` (Public): The GitHub branch no longer fails with a "term is not recognized" error.
+- `Approve-PSUPullRequest` and `Complete-PSUPullRequest` (Public): Both now report a clear installation message when an Azure DevOps repository is detected but `OMG.PSUtilities.AzureDevOps` is not installed.
+
 ## [1.0.21] - 27th July 2026
 ### Documentation
 - `Get-PSUUserEnvironmentVariable` (Public): updated the pipeline example to use `GEMINI_API_KEY`, following the environment variable rename in `OMG.PSUtilities.AI` 1.0.43.

--- a/OMG.PSUtilities.Core/OMG.PSUtilities.Core.psd1
+++ b/OMG.PSUtilities.Core/OMG.PSUtilities.Core.psd1
@@ -12,7 +12,7 @@
 RootModule = 'OMG.PSUtilities.Core.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.21'
+ModuleVersion = '1.1.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -74,6 +74,7 @@ RequiredModules = @(
 FunctionsToExport = @(
     'Approve-PSUGithubPullRequest',
     'Approve-PSUPullRequest',
+    'Complete-PSUGithubPullRequest',
     'Complete-PSUPullRequest',
     'Export-PSUExcel',
     'Find-PSUFilesContainingText',

--- a/OMG.PSUtilities.Core/OMG.PSUtilities.Core.psm1
+++ b/OMG.PSUtilities.Core/OMG.PSUtilities.Core.psm1
@@ -20,6 +20,7 @@ Get-ChildItem -Path "$PSScriptRoot\Public\*.ps1" -Recurse -ErrorAction SilentlyC
 $PublicFunctions = @(
     'Approve-PSUGithubPullRequest',
     'Approve-PSUPullRequest',
+    'Complete-PSUGithubPullRequest',
     'Complete-PSUPullRequest',
     'Export-PSUExcel',
     'Find-PSUFilesContainingText',

--- a/OMG.PSUtilities.Core/Public/Approve-PSUPullRequest.ps1
+++ b/OMG.PSUtilities.Core/Public/Approve-PSUPullRequest.ps1
@@ -105,6 +105,10 @@ function Approve-PSUPullRequest {
             } elseif ($remoteUrl -match 'dev\.azure\.com|visualstudio\.com') {
                 Write-Verbose "Detected Azure DevOps repository"
 
+                if (-not (Get-Command -Name 'Approve-PSUADOPullRequest' -ErrorAction SilentlyContinue)) {
+                    throw "Azure DevOps pull requests require the OMG.PSUtilities.AzureDevOps module. Install it using: Install-Module -Name OMG.PSUtilities.AzureDevOps -Scope CurrentUser"
+                }
+
                 # Map approval types to Azure DevOps vote values
                 $vote = switch ($ApprovalType) {
                     'Approve' { 10 }

--- a/OMG.PSUtilities.Core/Public/Complete-PSUGithubPullRequest.ps1
+++ b/OMG.PSUtilities.Core/Public/Complete-PSUGithubPullRequest.ps1
@@ -1,0 +1,211 @@
+function Complete-PSUGithubPullRequest {
+    <#
+    .SYNOPSIS
+        Completes (merges) a pull request in GitHub using REST API.
+
+    .DESCRIPTION
+        This function merges an open pull request in GitHub by its number and optionally deletes the
+        source branch afterwards. It supports the merge, squash, and rebase strategies offered by the
+        GitHub pull request merge API.
+
+    .PARAMETER Owner
+        (Optional) The GitHub repository owner (username or organization).
+        Default value is auto-detected from git remote origin URL.
+
+    .PARAMETER Repository
+        (Optional) The GitHub repository name.
+        Default value is auto-detected from git remote origin URL.
+
+    .PARAMETER PullRequestNumber
+        (Mandatory) The number/ID of the pull request to complete.
+
+    .PARAMETER MergeMethod
+        (Optional) The merge strategy to use:
+        - 'merge': Create a merge commit
+        - 'squash': Squash the commits into a single commit
+        - 'rebase': Rebase the commits onto the base branch
+        Default value is 'merge'.
+
+    .PARAMETER CommitTitle
+        (Optional) The title of the merge commit. GitHub generates one when omitted.
+
+    .PARAMETER CommitMessage
+        (Optional) The body of the merge commit. GitHub generates one when omitted.
+
+    .PARAMETER DeleteBranch
+        (Optional) Switch parameter to delete the source branch after a successful merge.
+
+    .PARAMETER Token
+        (Optional) GitHub Personal Access Token for authentication.
+        Default value is $env:GITHUB_TOKEN. Set using: Set-PSUUserEnvironmentVariable -Name "GITHUB_TOKEN" -Value "value_of_token"
+
+    .EXAMPLE
+        Complete-PSUGithubPullRequest -PullRequestNumber 42
+
+        Merges pull request #42 using auto-detected repository and a merge commit.
+
+    .EXAMPLE
+        Complete-PSUGithubPullRequest -PullRequestNumber 42 -MergeMethod "squash" -DeleteBranch
+
+        Squash merges pull request #42 and deletes the source branch.
+
+    .EXAMPLE
+        Complete-PSUGithubPullRequest -Owner "myuser" -Repository "myrepo" -PullRequestNumber 42 -CommitTitle "Feature complete"
+
+        Merges pull request #42 in an explicit repository with a custom merge commit title.
+
+    .OUTPUTS
+        [PSCustomObject]
+
+    .NOTES
+        Author: Lakshmanachari Panuganti
+        Date: 6th August 2026
+        Requires: GitHub Personal Access Token with repo permissions
+
+    .LINK
+        https://github.com/lakshmanachari-panuganti/OMG.PSUtilities/tree/main/OMG.PSUtilities.Core
+        https://www.linkedin.com/in/lakshmanachari-panuganti/
+        https://www.powershellgallery.com/packages/OMG.PSUtilities.Core
+        https://docs.github.com/en/rest/pulls/pulls#merge-a-pull-request
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSAvoidUsingWriteHost',
+        '',
+        Justification = 'This is intended for this function to display formatted output to the user on the console'
+    )]
+    param (
+        [Parameter()]
+        [string]$Owner,
+
+        [Parameter()]
+        [string]$Repository,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [int]$PullRequestNumber,
+
+        [Parameter()]
+        [ValidateSet('merge', 'squash', 'rebase')]
+        [string]$MergeMethod = 'merge',
+
+        [Parameter()]
+        [string]$CommitTitle,
+
+        [Parameter()]
+        [string]$CommitMessage,
+
+        [Parameter()]
+        [switch]$DeleteBranch,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$Token = $env:GITHUB_TOKEN
+    )
+
+    process {
+        try {
+            # Auto-detect repository info if not provided
+            if (-not $Owner -or -not $Repository) {
+                $remoteUrl = git remote get-url origin 2>$null
+                if (-not $remoteUrl) {
+                    throw "No git remote origin found and Owner/Repository not specified."
+                }
+
+                if ($remoteUrl -match 'github\.com[/:]([^/]+)/([^/]+?)(?:\.git)?/?$') {
+                    if (-not $Owner) { $Owner = $matches[1] }
+                    if (-not $Repository) { $Repository = $matches[2] }
+                } else {
+                    throw "Could not parse GitHub repository from remote URL: $remoteUrl. Please specify Owner and Repository parameters."
+                }
+            }
+
+            # Validate token
+            if (-not $Token) {
+                throw "GitHub token not found. Set it using: Set-PSUUserEnvironmentVariable -Name 'GITHUB_TOKEN' -Value 'your-token'"
+            }
+
+            # Prepare headers
+            $headers = @{
+                'Authorization'        = "Bearer $Token"
+                'Accept'               = 'application/vnd.github.v3+json'
+                'X-GitHub-Api-Version' = '2022-11-28'
+            }
+
+            # Get PR details first to validate it exists and to find the source branch
+            $prUri = "https://api.github.com/repos/$Owner/$Repository/pulls/$PullRequestNumber"
+            Write-Verbose "Getting pull request details from: $prUri"
+
+            $prDetails = Invoke-RestMethod -Method Get -Uri $prUri -Headers $headers -ErrorAction Stop
+
+            if ($prDetails.state -ne 'open') {
+                throw "Pull request #$PullRequestNumber is '$($prDetails.state)' and cannot be completed."
+            }
+
+            # Prepare merge body
+            $body = @{
+                merge_method = $MergeMethod
+            }
+
+            if ($CommitTitle) {
+                $body.commit_title = $CommitTitle
+            }
+
+            if ($CommitMessage) {
+                $body.commit_message = $CommitMessage
+            }
+
+            $bodyJson = $body | ConvertTo-Json -Depth 10
+
+            $mergeUri = "$prUri/merge"
+            Write-Verbose "Completing pull request #$PullRequestNumber in repository: $Owner/$Repository"
+            Write-Verbose "Merge method: $MergeMethod"
+            Write-Verbose "API URI: $mergeUri"
+
+            if (-not $PSCmdlet.ShouldProcess("$Owner/$Repository pull request #$PullRequestNumber", "Complete with $MergeMethod")) {
+                return
+            }
+
+            $response = Invoke-RestMethod -Method Put -Uri $mergeUri -Headers $headers -Body $bodyJson -ContentType "application/json" -ErrorAction Stop
+
+            Write-Host "Successfully completed pull request #$PullRequestNumber" -ForegroundColor Green
+            Write-Host "PR URL: $($prDetails.html_url)" -ForegroundColor Cyan
+
+            # Delete the source branch only after a confirmed merge
+            $sourceBranch = $prDetails.head.ref
+            $branchDeleted = $false
+
+            if ($DeleteBranch -and $response.merged) {
+                $branchUri = "https://api.github.com/repos/$Owner/$Repository/git/refs/heads/$sourceBranch"
+                Write-Verbose "Deleting source branch: $sourceBranch"
+
+                try {
+                    Invoke-RestMethod -Method Delete -Uri $branchUri -Headers $headers -ErrorAction Stop | Out-Null
+                    $branchDeleted = $true
+                    Write-Host "Deleted source branch: $sourceBranch" -ForegroundColor Green
+                } catch {
+                    Write-Warning "Merged pull request #$PullRequestNumber but could not delete branch '$sourceBranch': $($_.Exception.Message)"
+                }
+            }
+
+            # Return structured result
+            [PSCustomObject]@{
+                PullRequestNumber = $PullRequestNumber
+                Merged            = $response.merged
+                MergeMethod       = $MergeMethod
+                MergeCommitSha    = $response.sha
+                Message           = $response.message
+                SourceBranch      = $sourceBranch
+                TargetBranch      = $prDetails.base.ref
+                BranchDeleted     = $branchDeleted
+                Owner             = $Owner
+                Repository        = $Repository
+                PullRequestUrl    = $prDetails.html_url
+                PSTypeName        = 'PSU.GitHub.PullRequestCompletion'
+            }
+        }
+        catch {
+            $PSCmdlet.ThrowTerminatingError($_)
+        }
+    }
+}

--- a/OMG.PSUtilities.Core/Public/Complete-PSUPullRequest.ps1
+++ b/OMG.PSUtilities.Core/Public/Complete-PSUPullRequest.ps1
@@ -118,6 +118,10 @@ function Complete-PSUPullRequest {
             } elseif ($remoteUrl -match 'dev\.azure\.com|visualstudio\.com') {
                 Write-Verbose "Detected Azure DevOps repository"
 
+                if (-not (Get-Command -Name 'Complete-PSUADOPullRequest' -ErrorAction SilentlyContinue)) {
+                    throw "Azure DevOps pull requests require the OMG.PSUtilities.AzureDevOps module. Install it using: Install-Module -Name OMG.PSUtilities.AzureDevOps -Scope CurrentUser"
+                }
+
                 if ($CommitTitle -or $CommitMessage) {
                     Write-Warning "Custom commit title/message not supported for Azure DevOps pull requests."
                 }


### PR DESCRIPTION
**4 of 5.** Based on #107.

## The bug

`Complete-PSUPullRequest` detects the platform from the git remote and routes GitHub repositories to `Complete-PSUGithubPullRequest`:

```powershell
Write-Host "Completing GitHub pull request #$PullRequestNumber..." -ForegroundColor Blue
return Complete-PSUGithubPullRequest @params
```

That command was never written. `git grep 'function Complete-PSUGithubPullRequest'` returns nothing — the only occurrence anywhere in the repository is the call site. The GitHub branch has always failed with `The term 'Complete-PSUGithubPullRequest' is not recognized`. Only the Azure DevOps branch ever worked.

## The fix

Implements the command, following `Approve-PSUGithubPullRequest` line for line: same repository auto-detection from the git remote, same `$env:GITHUB_TOKEN` default, same header set, same structured `[PSCustomObject]` with a `PSTypeName`, same `$PSCmdlet.ThrowTerminatingError($_)`.

Behaviour worth reviewing:

- Supports `merge`, `squash`, `rebase` (the three GitHub actually offers — `Complete-PSUPullRequest` already downgrades `rebaseMerge` to `rebase` before calling).
- Refuses a pull request that is not `open`, rather than letting the API return an opaque 405.
- Deletes the source branch **only** after GitHub confirms `merged`, and a failed branch delete warns instead of throwing — the merge already succeeded and should not be reported as a failure.
- `SupportsShouldProcess`, so `-WhatIf` works on an irreversible operation.

## Cross-module guard

Both Core dispatchers call into `OMG.PSUtilities.AzureDevOps`, which Core's manifest does not declare as a dependency. On a machine with only Core installed, the Azure DevOps branch failed the same opaque way. `Approve-PSUPullRequest` and `Complete-PSUPullRequest` now check first and name the module to install.

Declaring the dependency in the manifest was the alternative, but that would force every Core user to pull in the Azure DevOps module for two optional dispatch paths.

## Versions

`Core 1.0.21 → 1.1.0` (new public command), manifest and `.psm1` exports updated, CHANGELOG entry added.

## Validation

`.\build\Test-Repository.ps1 -IncludeScriptAnalyzer` — 9 modules, 0 analyzer warnings. Core exports 30 commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)